### PR TITLE
feature: add support for highlighting Markdown fenced code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
                 "language": "textproto",
                 "scopeName": "source.textproto",
                 "path": "./syntaxes/textproto.tmLanguage.json"
+            },
+            {
+                "scopeName": "markdown.textproto.codeblock",
+                "path": "./syntaxes/codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.textproto": "textproto"
+                }
             }
         ]
     },

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#textproto-code-block"
+        }
+    ],
+    "repository": {
+        "textproto-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(textproto)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language"
+                },
+                "6": {
+                    "name": "fenced_code.block.language.attributes"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.textproto",
+                    "patterns": [
+                        {
+                            "include": "source.textproto"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.textproto.codeblock"
+}


### PR DESCRIPTION
This feature is based on [this idea](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example), I used [this extension](https://github.com/colinfang/markdown-julia) for reference.