### PR TITLE
feature: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  push:
+  release:
+    types:
+      - created
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: docker://colinfang/vsce
+        with:
+          args: package
+      - uses: actions/upload-artifact@v2-preview
+        with:
+          name: vsix
+          path: "*.vsix"
+
+  release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - uses: actions/download-artifact@v2-preview
+        with:
+          name: vsix
+      - id: find_file_name
+        run: echo "::set-output name=file::$(ls *.vsix)"
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.find_file_name.outputs.file }}
+          asset_name: ${{ steps.find_file_name.outputs.file }}
+          asset_content_type: application/zip

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "author": {
         "name": "Justin Walsh"
     },
+    "contributors": [
+        "Marcus R. Brown <contact@marcusrbrown.com>"
+    ],
     "keywords": [
         "protobuf",
         "protocol-buffers"


### PR DESCRIPTION
The workflow was copied from the one used in [juila-markdown](https://github.com/colinfang/markdown-julia/blob/master/.github/workflows/ci.yml). It is a starting point, and for now it will create preview artifacts of the VSIX on every push, and attach the artifact to the release files.